### PR TITLE
chore: remove netlify-lambda

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  functions = "functions"
+  functions = "src"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "server": "nodemon index.js",
     "client": "npm start --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
-    "heroku-postbuild": "NPM_CONFIG_PRODUCTION=false npm install --prefix client && npm run build --prefix client",
-    "start":"./node_modules/.bin/netlify-lambda serve src",
-    "build":"./node_modules/.bin/netlify-lambda build src"
+    "heroku-postbuild": "NPM_CONFIG_PRODUCTION=false npm install --prefix client && npm run build --prefix client"
   },
   "author": "",
   "license": "ISC",
@@ -27,7 +25,6 @@
     "jsonwebtoken": "^8.5.1",
     "multer": "^1.4.2",
     "mysql": "^2.17.1",
-    "netlify-lambda": "^2.0.1",
     "serverless-http": "^2.5.0",
     "underscore": "^1.9.1"
   }


### PR DESCRIPTION
Related to https://github.com/netlify/cli/issues/1121.
No need for `netlify-lambda` if you don't need a build step.

Running `netlify dev` and trying to access the API fails with:
```
Error: connect ECONNREFUSED 127.0.0.1:3306
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1141:16)
    --------------------
    at Protocol._enqueue (/Users/erezrokah/Code/github/socialserver/node_modules/mysql/lib/protocol/Protocol.js:144:48)
    at Protocol.handshake (/Users/erezrokah/Code/github/socialserver/node_modules/mysql/lib/protocol/Protocol.js:51:23)
    at Connection.connect (/Users/erezrokah/Code/github/socialserver/node_modules/mysql/lib/Connection.js:119:18)
    at Object.<anonymous> (/Users/erezrokah/Code/github/socialserver/src/config/dbconfig.js:18:4)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (internal/modules/cjs/helpers.js:72:18) {
  errno: 'ECONNREFUSED',
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 3306,
  fatal: true
}
```